### PR TITLE
version bump to 0.6.4-2

### DIFF
--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ package main
 var GitCommit string
 
 // The main version number that is being run at the moment.
-const Version = "0.6.4-1"
+const Version = "0.6.4-2"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
This is required to replace the old rpm during system updates.